### PR TITLE
Updates documentation and disables NFC

### DIFF
--- a/docs/scheme.md
+++ b/docs/scheme.md
@@ -260,9 +260,7 @@ payto://void/geo?loc=48.8582,2.2945
 
 Always validate the authenticity and correctness of PAYTO URIs. For irreversible assets, users must confirm the recipient address and amount before initiating a transfer.
 
-## Normative References
-
-- [RFC3986]: https://www.rfc-editor.org/rfc/rfc3986 (URI: Generic Syntax)
-- [RFC8905]: https://www.rfc-editor.org/rfc/rfc8905 (The 'payto' URI Scheme for Payments)
-- [ORIC]: https://payto.onl/solutions/oric (Organizational Routing Identifier Code)
-- [ICAN]: https://payto.onl/solutions/ican (International Crypto Asset Network)
+[RFC3986]: https://www.rfc-editor.org/rfc/rfc3986 (URI: Generic Syntax)
+[RFC8905]: https://www.rfc-editor.org/rfc/rfc8905 (The 'payto' URI Scheme for Payments)
+[ORIC]: https://payto.onl/solutions/oric (Organizational Routing Identifier Code)
+[ICAN]: https://payto.onl/solutions/ican (International Crypto Asset Network)

--- a/src/lib/helpers/paypass-ios.helper.ts
+++ b/src/lib/helpers/paypass-ios.helper.ts
@@ -792,10 +792,10 @@ export async function buildAppleWalletPayPass(config: AppleWalletPayPassConfig):
 	const passData: any = {
 		...basicData,
 		storeCard,
-		nfc: {
+		/*nfc: {
 			message: payload.basicLink,
 			requiresAuthentication: true
-		}
+		}*/
 	};
 
 	// Barcode


### PR DESCRIPTION
Refactors the documentation by removing the "Normative References" heading for better readability.

Temporarily disables NFC functionality in the Apple Wallet PayPass to address potential issues or pending features.