### PR TITLE
Validates authority based on ID only.

### DIFF
--- a/src/routes/pass/+server.ts
+++ b/src/routes/pass/+server.ts
@@ -138,7 +138,7 @@ export async function POST({ request, url, fetch, platform }: RequestEvent) {
 	if (authorityField) {
 		authorityItem = authorityField.toLowerCase();
 		kvData = await KV.get(authorityItem);
-		if (!kvData?.id || !kvData?.identifier) {
+		if (!kvData?.id) {
 			throw error(400, `Invalid authority: ${authorityItem}`);
 		}
 		authority = kvData.id;


### PR DESCRIPTION
The change modifies the validation logic for authority items. It removes the check for the `identifier` property, now relying solely on the presence of the `id` property to determine the validity of the authority. This simplifies the validation process.