### PR TITLE
Adds ORIC verification for organization name

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Issuing authorities[^authority] deliver an object like this example to the email
 ```jsonc
 {
   "id": "pingchb2", // ID in lowercase, no spaces
+  "oric": "PINGCHB2", // ORIC/BIC code of the organization (optional)
   "name": "Ping Exchange", // Name of the organization
   "url": "https://ping.exchange", // Website of the organization
   "icons": { // Organization icons
@@ -138,6 +139,10 @@ Issuing authorities[^authority] deliver an object like this example to the email
 
 - **`id`** (required): The unique authority ID of the Pass. Must be a valid ID in lowercase, no spaces.
   - Example: `"pingchb2"`
+
+- **`oric`** (optional): The ORIC/BIC code of the organization. If set, it is used to verify the organization name. It will be marked as verified if the organization name matches the receiving address.
+  - Example: `"PINGCHB2"`
+  - Default: none
 
 - **`name`** (required): The organization name displayed on the Pass. If set, it overrides the user's custom organization name.
   - Example: `"PayTo"`, `"My Company Inc."`

--- a/src/lib/helpers/paypass-operator.helper.ts
+++ b/src/lib/helpers/paypass-operator.helper.ts
@@ -102,19 +102,28 @@ export function getExpirationDate(deadlineValue: number | string | null | undefi
 
 export async function getVerifiedOrganizationName({
 	org,
-	kvName,
+	kvData,
 	address,
 	network
 }: {
 	org?: string | null;
-	kvName?: string | null;
+	kvData?: any | null;
 	address?: string | null;
 	network?: string | null;
 }): Promise<string> {
 	const fallback = 'PayPass';
 
-	if (kvName) {
-		return `${kvName} ✅`;
+	if (kvData && kvData.name && kvData.oric && address) {
+		try {
+			const oricResult = await verifyOrganization(kvData.oric, address);
+			if (oricResult.isVerified) {
+				return `${kvData.name} ✅`;
+			}
+		} catch (error) {
+			// Ignore ORIC verification failure and fall back to other checks
+		}
+	} else if (kvData && kvData.name) {
+		return kvData.name;
 	}
 
 	const sanitized = standardizeOrg(org ?? null);

--- a/src/routes/pass/+server.ts
+++ b/src/routes/pass/+server.ts
@@ -270,7 +270,7 @@ export async function POST({ request, url, fetch, platform }: RequestEvent) {
 		const companyName = standardizeOrg(originatorName);
 		const orgName = await getVerifiedOrganizationName({
 			org: design.org || null,
-			kvName: originatorName,
+			kvData: kvData || null,
 			address: destination,
 			network
 		});


### PR DESCRIPTION
Enables verification of the organization name using the ORIC/BIC code.

If an ORIC code is provided, the system attempts to verify the organization name against it. A checkmark is displayed next to the name if the verification is successful. This enhances the trustworthiness of displayed organization names.