### PR TITLE
Updates Google Wallet save link and redirect logic

### DIFF
--- a/src/lib/helpers/paypass-android.helper.ts
+++ b/src/lib/helpers/paypass-android.helper.ts
@@ -697,7 +697,7 @@ export async function buildGoogleWalletPayPassSaveLink(config: GoogleWalletPayPa
 			displayText: { defaultValue: { language: locale, value: getPaypassLocalizedValue('paypass.pay', locale) || 'Pay' } },
 			webAppLinkInfo: {
 				appTarget: {
-					targetUri: { uri: payload.fullLink, description: getPaypassLocalizedValue('paypass.pay', locale) || 'Pay' }
+					targetUri: { uri: `payto://${payload.props.network}`, description: getPaypassLocalizedValue('paypass.pay', locale) || 'Pay' }
 				}
 			}
 		},

--- a/src/routes/pass/+server.ts
+++ b/src/routes/pass/+server.ts
@@ -426,13 +426,15 @@ export async function POST({ request, url, fetch, platform }: RequestEvent) {
 				}
 			}
 
-			// Default: Redirect to Google Wallet save URL
-			// Use ?noRedirect=1 or ?format=json to get JSON response instead
+			// For form submissions: always redirect to Google Wallet (for pure HTML forms)
+			// For API calls (JSON): return JSON unless noRedirect is explicitly set
 			const noRedirect = url.searchParams.get('noRedirect') === '1' || url.searchParams.get('format') === 'json';
 			const wantsJson = request.headers.get('accept')?.includes('application/json') && !request.headers.get('accept')?.includes('text/html');
 
-			if (!noRedirect && !wantsJson) {
-				// Redirect directly to Google Wallet save URL (default behavior)
+			// Always redirect for form submissions (pure HTML forms)
+			// For JSON API calls, redirect unless explicitly requesting JSON
+			if (isFormSubmission || (!noRedirect && !wantsJson)) {
+				// Redirect directly to Google Wallet save URL (302 redirect for form submissions)
 				return new Response(null, {
 					status: 302,
 					headers: {
@@ -441,7 +443,7 @@ export async function POST({ request, url, fetch, platform }: RequestEvent) {
 				});
 			}
 
-			// Return JSON response (when explicitly requested)
+			// Return JSON response (for API calls when explicitly requested)
 			return json({ saveUrl, id: objectId, classId: finalClassId, gwObject, gwClass });
 		} else if (os === 'ios') {
 			/* -------------------------------------------------------------


### PR DESCRIPTION
Updates the Google Wallet save link to use a `payto://` scheme with the network name.

Refines the redirect logic for saving to Google Wallet. It now always redirects for form submissions (pure HTML forms) and redirects for JSON API calls unless `noRedirect` is explicitly specified. This ensures proper behavior for both form-based and API-based integrations.